### PR TITLE
Simplify secrets management for the repo

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -3,4 +3,3 @@ export SECRETS_DIR=${PROJECT_DIR}/secrets
 export WORK_DIR=${PROJECT_DIR}/work
 
 PATH=${PROJECT_DIR}/bin:${PATH}
-

--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,5 @@
 secrets/*
 !secrets/*.enc
 !secrets/README.md
-!secrets/REDACTED-lab.yml
-dns/tls/privkey.pem
 work/*
-!work/README.md
+!work/.gitkeep

--- a/bin/secrets
+++ b/bin/secrets
@@ -1,0 +1,33 @@
+#!/usr/bin/env python
+
+import os
+import subprocess
+import typer
+
+app = typer.Typer()
+secrets_dir = os.environ.get("SECRETS_DIR")
+
+@app.command()
+def init():
+    if not os.path.exists(secrets_dir):
+        os.mkdir(secrets_dir)
+
+@app.command()
+def encrypt():
+    for file in os.listdir(secrets_dir):
+        path = os.path.join(secrets_dir, file)
+        if os.path.isfile(path) and not file.endswith(".enc"):
+            encrypted = open("{}.enc".format(path), "wb+")
+            subprocess.run(["keybase", "pgp", "encrypt", "-i", path], stdout=encrypted)
+
+@app.command()
+def decrypt():
+    for file in os.listdir(secrets_dir):
+        path = os.path.join(secrets_dir, file)
+        if os.path.isfile(path) and file.endswith(".enc"):
+            decrypted = open(path[0:-4], "wb+")
+            subprocess.run(["keybase", "pgp", "decrypt", "-i", path], stdout=decrypted )
+
+
+if __name__ == "__main__":
+    app()


### PR DESCRIPTION
# TL;DR

Uses my standard approach to managing secrets in a repo

# Details

Adds the `secerts` script for easily encrypting and decrypting
secrets stored in the `secrets` directory as part of the repo.
Also add some nice ergonomic features with `.envrc` and `.gitingore`
to assure `secrets` is in your path and ignore unencrypted secrets.
