### PR TITLE
Fixes defect in vault policy setup

### DIFF
--- a/bin/add-vault-to-concourse
+++ b/bin/add-vault-to-concourse
@@ -16,6 +16,7 @@ path "concourse/*" {
     policy = "read"
 }
 POLICY
+)
 
 if ! vault read --format json auth/approle/role/concourse/role-id | jq -r .data.role_id ; then
   vault write auth/approle/role/concourse policies=concourse period=1h


### PR DESCRIPTION
TL;DR
-----

Corrects policy setup in `add-vault-to-concourse` script

Details
-------

Fixes punctuation in the `add-vault-to-concourse` script where the
policy set command was missing a parentheiss and erring out.
