### PR TITLE
Adds scripts to configure vault's ODIC connection

### DIFF
--- a/bin/add-oidc-group-to-vault
+++ b/bin/add-oidc-group-to-vault
@@ -1,6 +1,4 @@
 #!/usr/bin/env bash
-set -x
-
 GROUP=${1}
 
 vault write identity/group name="${GROUP}" type="external" policies="${GROUP}" metadata=responsibility="Manage platform secrets"
@@ -8,16 +6,17 @@ vault write identity/group name="${GROUP}" type="external" policies="${GROUP}" m
 GROUP_ID=$(vault read -field=id identity/group/name/${GROUP})
 OIDC_AUTH_ACCESSOR=$(vault auth list -format=json  | jq -r '."oidc/".accessor')
 
-vault write identity/group-alias name="${GROUP}"
-  mount_accessor="$OIDC_AUTH_ACCESSOR"
+vault write identity/group-alias name="${GROUP}" \
+  mount_accessor="$OIDC_AUTH_ACCESSOR" \
   canonical_id="$GROUP_ID"
 
+vault policy write ${GROUP} ${PROJECT_DIR}/vault/policy/${GROUP}.hcl
+
 vault write auth/oidc/role/${GROUP} \
-  bound_audiences="${yq e .okta.vault-app-client-id ${PARAMS_YAML}" \
+  bound_audiences="$(yq e .okta.vault-app-client-id ${PARAMS_YAML})" \
   allowed_redirect_uris="https://vault.shortrib.dev/ui/vault/auth/oidc/oidc/callback" \
   allowed_redirect_uris="http://localhost:8250/oidc/callback" \
   oidc_scopes=groups,profile,openid,email \
   user_claim="sub" \
-  policies="reader" \
+  policies="${GROUP}" \
   groups_claim="groups" 
-

--- a/bin/add-oidc-group-to-vault
+++ b/bin/add-oidc-group-to-vault
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+set -x
+
+GROUP=${1}
+
+vault write identity/group name="${GROUP}" type="external" policies="${GROUP}" metadata=responsibility="Manage platform secrets"
+ 
+GROUP_ID=$(vault read -field=id identity/group/name/${GROUP})
+OIDC_AUTH_ACCESSOR=$(vault auth list -format=json  | jq -r '."oidc/".accessor')
+
+vault write identity/group-alias name="${GROUP}"
+  mount_accessor="$OIDC_AUTH_ACCESSOR"
+  canonical_id="$GROUP_ID"
+
+vault write auth/oidc/role/${GROUP} \
+  bound_audiences="${yq e .okta.vault-app-client-id ${PARAMS_YAML}" \
+  allowed_redirect_uris="https://vault.shortrib.dev/ui/vault/auth/oidc/oidc/callback" \
+  allowed_redirect_uris="http://localhost:8250/oidc/callback" \
+  oidc_scopes=groups,profile,openid,email \
+  user_claim="sub" \
+  policies="reader" \
+  groups_claim="groups" 
+

--- a/bin/add-oidc-to-vault
+++ b/bin/add-oidc-to-vault
@@ -1,0 +1,27 @@
+h!/usr/bin/env bash
+set -x
+
+vault auth enable oidc
+vault write auth/oidc/config \
+  oidc_discovery_url="https://$(yq e .okta.auth-server-fqdn ${PARAMS_YAML}" 
+  oidc_client_id="$(yq e .okta.vault-app-client-id ${PARAMS_YAML}" \
+  oidc_client_secret="$(yq e .okta.vault-app-client-secret ${PARAMS_YAML}"
+  default_role="reader"
+
+vault policy write reader <(
+for backend in $(vault secrets list --format json | jq 'with_entries(select(.value.type == "kv" )) | keys | .[] | .[:-1]'); do
+  cat <<POLICY
+  path "${backend}/*" {
+      policy = "read"
+  }
+POLICY
+done
+)
+
+vault write auth/oidc/role/reader \
+  bound_audiences="$(yq e .okta,vault-app-client-id ${PARAMS_YAML}" \
+  allowed_redirect_uris="https://$(yq e .vault.fqdn ${PARAMS_YAML})/ui/vault/auth/oidc/oidc/callback" \
+  allowed_redirect_uris="http://localhost:8250/oidc/callback" \
+  user_claim="sub" \
+  policies="reader"
+

--- a/bin/add-oidc-to-vault
+++ b/bin/add-oidc-to-vault
@@ -1,11 +1,11 @@
-h!/usr/bin/env bash
+#!/usr/bin/env bash
 set -x
 
 vault auth enable oidc
 vault write auth/oidc/config \
-  oidc_discovery_url="https://$(yq e .okta.auth-server-fqdn ${PARAMS_YAML}" 
-  oidc_client_id="$(yq e .okta.vault-app-client-id ${PARAMS_YAML}" \
-  oidc_client_secret="$(yq e .okta.vault-app-client-secret ${PARAMS_YAML}"
+  oidc_discovery_url="https://$(yq e .okta.auth-server-fqdn ${PARAMS_YAML})" \
+  oidc_client_id="$(yq e .okta.vault-app-client-id ${PARAMS_YAML})" \
+  oidc_client_secret="$(yq e .okta.vault-app-client-secret ${PARAMS_YAML})" \
   default_role="reader"
 
 vault policy write reader <(
@@ -19,7 +19,7 @@ done
 )
 
 vault write auth/oidc/role/reader \
-  bound_audiences="$(yq e .okta,vault-app-client-id ${PARAMS_YAML}" \
+  bound_audiences="$(yq e .okta.vault-app-client-id ${PARAMS_YAML})" \
   allowed_redirect_uris="https://$(yq e .vault.fqdn ${PARAMS_YAML})/ui/vault/auth/oidc/oidc/callback" \
   allowed_redirect_uris="http://localhost:8250/oidc/callback" \
   user_claim="sub" \

--- a/vault/policy/platform-team.hcl
+++ b/vault/policy/platform-team.hcl
@@ -1,0 +1,7 @@
+# Enable and manage the key/value secrets engine at `concourse/` path
+
+# List, create, update, and delete key/value secrets
+path "concourse/*"
+{
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}

--- a/vault/policy/security.hcl
+++ b/vault/policy/security.hcl
@@ -1,3 +1,67 @@
-path "*" {
-  capabilities = [ "create", "read", "update", "delete", "list" ]
+# Read system health check
+path "sys/health"
+{
+  capabilities = ["read", "sudo"]
+}
+
+# Create and manage ACL policies broadly across Vault
+
+# List existing policies
+path "sys/policies/acl"
+{
+  capabilities = ["list"]
+}
+
+# Create and manage ACL policies
+path "sys/policies/acl/*"
+{
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Enable and manage authentication methods broadly across Vault
+
+# Manage auth methods broadly across Vault
+path "auth/*"
+{
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Create, update, and delete auth methods
+path "sys/auth/*"
+{
+  capabilities = ["create", "update", "delete", "sudo"]
+}
+
+# List auth methods
+path "sys/auth"
+{
+  capabilities = ["read"]
+}
+
+# Enable and manage the key/value secrets engine at `secret/` path
+
+# List, create, update, and delete key/value secrets
+path "secret/*"
+{
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Enable and manage the key/value secrets engine at `concourse/` path
+
+# List, create, update, and delete key/value secrets
+path "concourse/*"
+{
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# Manage secrets engines
+path "sys/mounts/*"
+{
+  capabilities = ["create", "read", "update", "delete", "list", "sudo"]
+}
+
+# List existing secrets engines.
+path "sys/mounts"
+{
+  capabilities = ["read"]
 }


### PR DESCRIPTION
TL;DR
-----

Adds two scripts that faciliates setting up OIDC auth for Vault

Details
-------

Impelemts two scripts to allow Vault logins with OIDC using the
Lab's Okta configuration.

* `add-oidc-to-vault` enables OIDC authentcation and associates
  the Okta client information with the vault instance
* `add-oidc-group-to-vault` simplifies joining Vault groups to
  Okta groups since it's kind of painful. Also follows a
  convention where the policy for group `$GROUP` is loaded from
  `${PROJECT_DIR}/vault/policy/${GROUP}.hcl`.

The changes also includes policies implementations for the Okta
groups `security` and `platform-team`.