### PR TITLE
Updates to support using TCE over TKG

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,7 +1,7 @@
 export PROJECT_DIR=${PWD}
 export SECRETS_DIR=${PROJECT_DIR}/secrets
 export WORK_DIR=${PROJECT_DIR}/work
-export TKG_LAB_DIR=${HOME}/workspace/tkg-lab
+export TCE_LAB_DIR=${HOME}/workspace/homelab/tce-lab
 
 PATH=${PROJECT_DIR}/bin:${PATH}
 

--- a/bin/deploy-gatekeeper
+++ b/bin/deploy-gatekeeper
@@ -1,0 +1,18 @@
+#!/bin/bash -e
+
+if [ ! $# -eq 1 ]; then
+  echo "Must supply cluster_name as args"
+  exit 1
+fi
+
+CLUSTER_NAME=$1
+
+kubectl config use-context $CLUSTER_NAME-admin@$CLUSTER_NAME
+
+VERSION=$(tanzu package available list gatekeeper.community.tanzu.vmware.com --namespace tanzu-kapp -oyaml | yq eval ".[0].version" -)
+
+tanzu package install gatekeeper \
+  --package-name gatekeeper.community.tanzu.vmware.com \
+  --version $VERSION \
+  --namespace tanzu-kapp \
+  --poll-timeout 10m0s

--- a/bin/generate-and-apply-vault
+++ b/bin/generate-and-apply-vault
@@ -16,7 +16,7 @@ helm repo update
 # NOTE: Through testing setting the OIDC CA in values.yaml did not work as expected, so we are mounting the let's encrypt CA onto the worker pods via ytt overlay
 helm template vault hashicorp/vault -f generated/$CLUSTER_NAME/vault/vault-values-contour.yaml --namespace $VAULT_NAMESPACE --version=0.17.1 | 
   ytt -f - -f ${PROJECT_DIR}/overlay/trust-certificate --ignore-unknown-comments \
-    --data-value certificate="$(cat ${TKG_LAB_DIR}/keys/letsencrypt-ca.pem)" \
+    --data-value certificate="$(cat ${TCE_LAB_DIR}/keys/letsencrypt-ca.pem)" \
     --data-value ca=letsencrypt > generated/$CLUSTER_NAME/vault/helm-manifest.yaml
 
 kubectl config use-context $CLUSTER_NAME-admin@$CLUSTER_NAME


### PR DESCRIPTION
TL;DR
-----

Adapts configuration and scripts for my switch from TKG to TCE

Details
-------

Since Tanzu Community Edition is now available, I wanted to shift
my lab to use that version over the commercial TKG. I'm still using
some commercial stuff (AVI and vSphere) since my VMUG membership
lets me do it, but I wanted to stick to the community stuff where
things were basically equal.

This update makes the cosmetic and functional changes needed to
deploy TCE over TKG. The main functional switch is installing
Gatekeeper since I'm not in a position to use TMC any longer. The
main cosmetic fix is renaming variables to have `TCE` in the name
over `TKG`.
