### PR TITLE
Adds script for creating a k8s service account

### DIFF
--- a/bin/create-service-account
+++ b/bin/create-service-account
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+set -e
+
+CLUSTER_NAME=${1}
+NAMESPACE=${2}
+SERVICE_ACCOUNT=${3}
+CLUSTER_ROLE=${4}
+
+kubectl config use-context ${CLUSTER_NAME}-admin@${CLUSTER_NAME}
+
+kubectl -n ${NAMESPACE} create serviceaccount ${SERVICE_ACCOUNT} -o yaml --dry-run=client | kubectl apply -f -
+kubectl create clusterrolebinding "${NAMESPACE}:${SERVICE_ACCOUNT}:${CLUSTER_ROLE}" \
+    --clusterrole="${CLUSTER_ROLE}" --serviceaccount="${NAMESPACE}:${SERVICE_ACCOUNT}" \
+    -o yaml --dry-run=client \
+  | kubectl apply -f -
+
+SECRET=$(kubectl get -n ${NAMESPACE} serviceaccount ${SERVICE_ACCOUNT} -o jsonpath='{.secrets[0].name}')
+TOKEN="$(kubectl get -n ${NAMESPACE} secret ${SECRET} -o jsonpath='{.data.token}' | base64 --decode)"
+CERTIFICATE="$(kubectl get -n ${NAMESPACE} secret ${SECRET} -o yaml | yq e '.data."ca.crt"' - | base64 --decode)"
+
+SERVER="$(kubectl config view --minify -o jsonpath='{.clusters[].cluster.server}')"
+
+export KUBECONFIG="${SECRETS_DIR}/kubeconfig.${CLUSTER_NAME}.${NAMESPACE}.${SERVICE_ACCOUNT}"
+kubectl config set-credentials ${SERVICE_ACCOUNT} --token="${TOKEN}"
+kubectl config set-cluster ${CLUSTER_NAME} --server=${SERVER} --embed-certs --certificate-authority=<(echo "${CERTIFICATE}")
+kubectl config set-context ${SERVICE_ACCOUNT}@${CLUSTER_NAME} --user=${SERVICE_ACCOUNT} --cluster ${CLUSTER_NAME}
+kubectl config use-context ${SERVICE_ACCOUNT}@${CLUSTER_NAME} 


### PR DESCRIPTION
TL;DR
-----

Implement a helper script to create a service acccount

Details
-------

Supports easily creating a Kuberentes service account to use for
connecting to the cluster. I needed this to support access from
Concourse to deploying stuff, and after stumbling through it a
couple of times manually I automated away the pain.
