### PR TITLE
Repairs Velero backups

### DIFF
--- a/bin/deploy-velero
+++ b/bin/deploy-velero
@@ -5,7 +5,7 @@ if [ ! $# -eq 1 ]; then
   exit 1
 fi
 
-echo "Beginning Velero install..."
+echo "Beginning Velero install"
 
 CLUSTER_NAME=$1
 kubectl config use-context $CLUSTER_NAME-admin@$CLUSTER_NAME
@@ -18,17 +18,18 @@ if [ "$IAAS" = "vsphere" ];
 then
   velero install \
       --provider gcp \
-      --plugins velero/velero-plugin-for-gcp:v1.3.0,vsphereveleroplugin/velero-plugin-for-vsphere:1.1.0 \
+      --plugins velero/velero-plugin-for-gcp:v1.3.0 \
       --bucket $VELERO_BUCKET \
-      --backup-location-config region=$VELERO_REGION \
-      --snapshot-location-config region=$VELERO_REGION \
-      --secret-file ${SECRETS_DIR}/credentials-velero.json
-  velero snapshot-location create vsl-vsphere --provider velero.io/vsphere
+      --prefix ${CLUSTER_NAME} \
+      --secret-file ${SECRETS_DIR}/credentials-velero.json \
+      --use-volume-snapshots=false \
+      --use-restic
 else
   velero install \
       --provider aws \
       --plugins velero/velero-plugin-for-aws:v1.1.0 \
       --bucket $VELERO_BUCKET \
+      --prefix ${CLUSTER_NAME} \
       --backup-location-config region=$VELERO_REGION \
       --snapshot-location-config region=$VELERO_REGION \
       --secret-file keys/credentials-velero
@@ -44,8 +45,9 @@ done
 if [ "$IAAS" = "vsphere" ];
 then
   velero schedule create daily-$CLUSTER_NAME-cluster-backup \
-    --schedule "0 7 * * *" \
-    --volume-snapshot-locations vsl-vsphere
+    --schedule "0 7 * * *"
+  velero schedule create --default-volumes-to-restic weekly-$CLUSTER_NAME-cluster-backup \
+    --schedule "20 10 * * 6"
 else
   velero schedule create daily-$CLUSTER_NAME-cluster-backup \
     --schedule "0 7 * * *" 


### PR DESCRIPTION
TL;DR
-----

Updates Velero install to get backups working correctly

Details
-------

I noticed Velero backups weren't working and let it sit for a bit
since I was a bit cocky about needing them. Two power issues in the
lab led to the need to rebuild it twice. Suddenly the backup issue
felt a lot more urgent.

This change deploys Velero in a way that properly backs up my lab
to GCP, including PVCs.

* Switches from using vSphere snapshots to restic since the config
  seemed a lot simpler and the limitations on restic aren't likely
  to hold me back too much.
* Adds a weekly backup that backs up all volumes, while the nighly
  only backs up object and logs (since they might be helpful if
  something goes bump in the night).

I wanted to switch to the Velero packages in TCE, but it isn't
quite there yet. I would have had to switch to using S3 to connect
to GCS and as I went down that path it got a bit tricky to make
sure it pointed to the right place. I'm going to drop that on
the backlog but I needed a backup right away since the power
sitatuion in the lab is still unstable and electricians are hard
to come by.
